### PR TITLE
Addition of MacBook Pro 7,1 support to asmc.ko

### DIFF
--- a/sys/dev/asmc/asmc.c
+++ b/sys/dev/asmc/asmc.c
@@ -221,6 +221,12 @@ struct asmc_model asmc_models[] = {
 	  ASMC_MBP5_TEMPS, ASMC_MBP5_TEMPNAMES, ASMC_MBP5_TEMPDESCS
 	},
 
+	{
+	"MacBookPro7,1", "Apple SMC MacBook Pro Core 2 Duo (mid 2010, 13-inch)",
+		ASMC_SMS_FUNCS_DISABLED, ASMC_FAN_FUNCS2, ASMC_LIGHT_FUNCS,
+		ASMC_MBP7_TEMPS, ASMC_MBP7_TEMPNAMES, ASMC_MBP7_TEMPDESCS
+	},
+
 	{ 
 	  "MacBookPro8,2", "Apple SMC MacBook Pro (early 2011)",
 	  ASMC_SMS_FUNCS, ASMC_FAN_FUNCS, ASMC_LIGHT_FUNCS,

--- a/sys/dev/asmc/asmcvar.h
+++ b/sys/dev/asmc/asmcvar.h
@@ -216,6 +216,21 @@ struct asmc_softc {
 				  "Heatsink 2", "Memory Controller", \
 				  "PCI Express Slot Pin", "PCI Express Slot (unk)" } 
 
+#define ASMC_MBP7_TEMPS         { "TB0T", "TB1T", "TB2T", \
+                                "TC0D", "TC0P", "TN0D", "TN0P", "TN0S", \
+                                "TN1D", "TN1F", "TN1G", "TN1S", \
+                                "Th1H", "Ts0P", "Ts0S" }
+
+#define ASMC_MBP7_TEMPNAMES     { "TB0T", "TB1T", "TB2T", \
+                                "TC0D", "TC0P", "TN0D", "TN0P", "TN0S", \
+                                "TN1D", "TN1F", "TN1G", "TN1S", \
+                                "Th1H", "Ts0P", "Ts0S" }
+
+#define ASMC_MBP7_TEMPDESCS     { "Battery charger proximity", "Battery TS1", "Battery TS2", \
+                                "CPU core 1", "CPU core 2", "Northbridge 0D", "Northbridge 0P", "Northbridge 0S", \
+                                "Northbridge 1D", "Northbridge 1F", "Northbridge 1G", "Northbridge 1S", \
+                                "Heatsink", "Left palm rest", "Right palm rest" }
+
 #define ASMC_MBP8_TEMPS		{ "TB0T", "TB1T", "TB2T", "TC0C", "TC0D", \
 				  "TC0E", "TC0F", "TC0P", "TC1C", "TC2C", \
 				  "TC3C", "TC4C", "TCFC", "TCGC", "TCSA", \


### PR DESCRIPTION
Added appropriate code & sensor information to allow the asmc kernel module to initialize & function on the MacBook Pro 7,1 model of Apple laptops.